### PR TITLE
fix possible encoding problem (force utf8)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -31,11 +31,14 @@ libraryDependencies ++=
 Nil
 
 
+
 EclipseKeys.withSource := true
 
 EclipseKeys.withJavadoc := true
 
 // javacOptions ++= Seq("-source", "1.7", "-target", "1.7")
+
+javacOptions ++= Seq("-encoding", "UTF-8")
 
 // scalacOptions += "-target:jvm-1.7"
 

--- a/src/main/scala/tm/text/Convert.scala
+++ b/src/main/scala/tm/text/Convert.scala
@@ -62,7 +62,7 @@ object Convert {
 
     // each line is assumed to be a sentence containing tokens
     // separated by space
-    val source = Source.fromFile(p.toFile)
+    val source = Source.fromFile(p.toFile, "UTF8")
     try {
       logger.debug("Reading {}", p.toFile)
       f(source.getLines.toList.map(tokenizeBySpace))


### PR DESCRIPTION
The reading function will report the following error in Windows.

```
Exception in thread "main" java.nio.charset.UnmappableCharacterException: Input length = 1
        at java.nio.charset.CoderResult.throwException(Unknown Source)
        at sun.nio.cs.StreamDecoder.implRead(Unknown Source)
        at sun.nio.cs.StreamDecoder.read(Unknown Source)
        at java.io.InputStreamReader.read(Unknown Source)
        at java.io.BufferedReader.fill(Unknown Source)
        at java.io.BufferedReader.readLine(Unknown Source)
        at java.io.BufferedReader.readLine(Unknown Source)
        at scala.io.BufferedSource$BufferedLineIterator.hasNext(BufferedSource.scala:72)
        at scala.collection.Iterator$class.foreach(Iterator.scala:893)
        at scala.collection.AbstractIterator.foreach(Iterator.scala:1336)
        at scala.collection.generic.Growable$class.$plus$plus$eq(Growable.scala:59)
        at scala.collection.mutable.ListBuffer.$plus$plus$eq(ListBuffer.scala:183)
        at scala.collection.mutable.ListBuffer.$plus$plus$eq(ListBuffer.scala:45)
        at scala.collection.TraversableOnce$class.to(TraversableOnce.scala:310)
        at scala.collection.AbstractIterator.to(Iterator.scala:1336)
        at scala.collection.TraversableOnce$class.toList(TraversableOnce.scala:294)
        at scala.collection.AbstractIterator.toList(Iterator.scala:1336)```
```
This PR should solve this problem by explicitly reading as UTF8 encoding.